### PR TITLE
frontend - Fix byterate in the header

### DIFF
--- a/frontend/src/worker/worker.ts
+++ b/frontend/src/worker/worker.ts
@@ -40,7 +40,8 @@ class WavEncoder {
         view.setUint16(20, 1, true);
         view.setUint16(22, 1, true);
         view.setUint32(24, this.sampleRate, true);
-        view.setUint32(28, this.sampleRate * 4, true);
+        // audio files are only mono
+        view.setUint32(28, this.sampleRate * 2, true);
         view.setUint16(32, 2, true);
         view.setUint16(34, 16, true);
         this.writeString(view, 36, 'data');


### PR DESCRIPTION
bad header causes problems in vlc player. By reading the header, it seems the ByteRate should be 64000 when it's actually 32000