### PR TITLE
fix styling for smaller screens, remove gap dependency to handle safari

### DIFF
--- a/frontend/src/components/frontpage/index.tsx
+++ b/frontend/src/components/frontpage/index.tsx
@@ -78,8 +78,12 @@ const MarsContainer = styled.div`
 const Mars = styled.div`
     content: url(/images/mars.svg);
     display: block;
-    max-width: 8rem;
+    max-width: 5rem;
     margin-bottom: 1rem;
+
+    @media (min-width: 30em) {
+        max-width: 8rem;
+    }
 `;
 
 const WelcomeTextContainer = styled.div``;


### PR DESCRIPTION
This should work better for small screens and removes the gap property from a few components. Gap is super nice, but not supported by Safari...