### PR TITLE
Change headset color to prevent confusion

### DIFF
--- a/frontend/src/components/chat/controls.tsx
+++ b/frontend/src/components/chat/controls.tsx
@@ -74,7 +74,7 @@ const Glow = styled.div<{ red?: boolean }>`
     opacity: 0.2;
     background: linear-gradient(
         to left,
-        ${({ red }) => (red ? '#FF99A1, #FF4F5E' : '#60C197, #A7DDC5')}
+        ${({ red }) => (red ? '#FF99A1, #FF4F5E' : '#6062C1, #A7BFDD')}
     );
     border-radius: 50%;
     filter: blur(6px);

--- a/frontend/src/components/chat/room.tsx
+++ b/frontend/src/components/chat/room.tsx
@@ -109,7 +109,7 @@ const Indicator = styled.div<{ connected: boolean }>`
     height: 0.5rem;
     width: 0.5rem;
     border-radius: 50%;
-    background-color: ${({ connected }) => (connected ? '#60C197' : 'gray')};
+    background-color: ${({ connected }) => (connected ? '#6062C1' : 'gray')};
 `;
 
 const ShareButton = styled.button<{ soloRecord: boolean }>`


### PR DESCRIPTION
When the headset icon is green and the record icon is red,
there is a stop-go confusion. Hopefully with a blue headset there'll be less confusion.