### PR TITLE
Change headset color to prevent confusion

### DIFF
--- a/frontend/src/components/chat/controls.tsx
+++ b/frontend/src/components/chat/controls.tsx
@@ -74,7 +74,7 @@ const Glow = styled.div<{ red?: boolean }>`
     opacity: 0.2;
     background: linear-gradient(
         to left,
-        ${({ red }) => (red ? '#FF99A1, #FF4F5E' : '#60C197, #A7DDC5')}
+        ${({ red }) => (red ? '#FF99A1, #FF4F5E' : '#6062C1, #A7BFDD')}
     );
     border-radius: 50%;
     filter: blur(6px);


### PR DESCRIPTION
When the headset icon is green and the record icon is red,
there is a stop-go confusion. Hopefully with a blue headset icon there'll be less confusion compared to the green one.

One advantage of keeping the Mic indicator green is that it aligns with the whole green - active and grey - inactive.
However one advantage of keeping the Mic indicator the same color as the Headset icon's glow is that the colors are matched and it'll signal their shared functionality.

There are good arguments for either direction.